### PR TITLE
Add scripts to npm package.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ env:
 cache:
   directories:
   - node_modules
-before_script:
+before_install:
 - psql -c 'create database foodujour_test;' -U postgres
-- ./node_modules/.bin/knex migrate:latest
+before_script:
 - ./node_modules/.bin/knex seed:run
 deploy:
   provider: heroku

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "connect-flash": "^0.1.1",
     "connect-session-knex": "^1.0.16",
     "cookie-parser": "^1.4.0",
+    "docco": "^0.7.0",
     "dotenv": "^1.2.0",
     "express": "^4.13.1",
     "express-session": "^1.12.0",
@@ -49,6 +50,10 @@
   },
   "scripts": {
     "start": "node ./server/app.js",
+    "docco": "./node_modules/.bin/docco -o client/docs/ server/**/*.js test/**/*.js",
+    "migrate:latest": "./node_modules/.bin/knex migrate:latest",
+    "seed": "./node_modules/.bin/knex seed:run",
+    "postinstall": "npm run migrate:latest && npm run docco",
     "dev": "./node_modules/.bin/pm2-dev start app.json",
     "test": "./test/run.sh"
   },


### PR DESCRIPTION
Add scripts to help with deploying on heroku.

Postinstall will now migrate the database and generate documentation